### PR TITLE
Revise single-GPU version inference server

### DIFF
--- a/src/core/infer_request.h
+++ b/src/core/infer_request.h
@@ -417,10 +417,19 @@ class InferenceRequest {
   uint64_t QueueStartNs() const { return queue_start_ns_; }
   uint64_t CaptureQueueStartNs()
   {
-    queue_start_ns_ = std::chrono::duration_cast<std::chrono::nanoseconds>(
-             std::chrono::steady_clock::now().time_since_epoch())
+    queue_start_ns_ = 
+             std::chrono::steady_clock::now().time_since_epoch()
              .count();
     return queue_start_ns_;
+  }
+  uint64_t CaptureQueueStartNs(uint64_t SLO)
+  {
+    queue_start_ns_ = 
+             std::chrono::steady_clock::now().time_since_epoch()
+             .count();
+    remain_time_ns_ = SLO + queue_start_ns_;
+
+    return remain_time_ns_;
   }
 
 #ifdef TRITON_ENABLE_STATS
@@ -458,23 +467,11 @@ class InferenceRequest {
   }
 #endif  // TRITON_ENABLE_STATS
 
-  void setTargetClock(unsigned int clock){
-    this->target_clock_ = clock;
-  }
-  
-  unsigned int getTargetClock(){
-    return this->target_clock_;
-  }
-
-  void setTargetThreads(unsigned int thread){
-    this->threads_ = thread;
-  }
-  
-  unsigned int getTargetThreads(){
-    return this->threads_;
-  }
-  unsigned int target_clock_;
+  unsigned int target_idx;
   unsigned int threads_;
+  uint64_t queue_start_ns_;
+  uint64_t remain_time_ns_;
+
  private:
   DISALLOW_COPY_AND_ASSIGN(InferenceRequest);
   friend std::ostream& operator<<(
@@ -537,7 +534,7 @@ class InferenceRequest {
 
   // Request timestamps. Queue start is needed for schedulers even
   // when statistics are not being collected.
-  uint64_t queue_start_ns_;
+  // uint64_t queue_start_ns_;
 
   // Whether the stats of the request should be collected.
   bool collect_stats_;


### PR DESCRIPTION
Enqueue와 Dequeue에서만 클럭을 조절하고 있었다. 실제로 request가 필요한 클럭 계산과 실제로 실행되는 시점까지
시간 차가 있어 latency를 위반할 가능성이 높다. 따라서 request가 실행되기 전에 클럭을 바꾸는 기능이 필요하다.

Request의 남은 시간을 계산하기 위한 변경점

- 기존에 GPU clock을 추적하기 위해서 cur_clock, target_clock를 사용했지만,
queue 길이(cur_idx)로 변경했다.
- exp_time 배열을 사전에 계산한다. cur_idx개의 request가 있을 때 inference time이다.

Latency violation을 줄이기 위한 수정사항

- OnSchedule() 전에 request의 남은 시간을 계산하고 현재 클럭(cur_idx로 계산)으로 동작할 때 남은
시간보다 적다면, cur_idx를 다시 계산하고 곧바로 클럭을 상승시킨다.
- OnSchedule() 후의 동작은 같다. 대신 queue의 head에 있는 request의 남은 시간이 클럭을 낮추어도
violation이 없다고 판단되면 그때 큐 탐색을 해서 오버헤드를 줄인다.